### PR TITLE
[TS]LPS-140477 Fix asset tags empty when update SEO layout

### DIFF
--- a/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/portlet/action/EditSEOMVCActionCommand.java
+++ b/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/portlet/action/EditSEOMVCActionCommand.java
@@ -14,6 +14,7 @@
 
 package com.liferay.layout.seo.web.internal.portlet.action;
 
+import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.seo.service.LayoutSEOEntryService;
@@ -100,6 +101,11 @@ public class EditSEOMVCActionCommand extends BaseMVCActionCommand {
 
 		String[] assetTagNames = _assetTagLocalService.getTagNames(
 			Layout.class.getName(), layout.getPlid());
+
+		long[] assetCategoryIds = AssetCategoryLocalServiceUtil.getCategoryIds(
+			Layout.class.getName(), layout.getPlid());
+
+		serviceContext.setAssetCategoryIds(assetCategoryIds);
 
 		serviceContext.setAssetTagNames(assetTagNames);
 


### PR DESCRIPTION
The original implement is from https://github.com/sontruongces/liferay-portal/pull/1
This one has passed my review.
The issue is described in ticket https://issues.liferay.com/browse/LPP-42824
### Problem overview
Update the layout SEO information will make the layout general tag information lost.
@sontruongces found that the previous version has the topic,assetTag and SEO inputs on the same page. Therefore the topic and assetTag information will be included as parameters. For this new version, the topci and assetTag are not included and make that information empty in serviceContext.
### Steps to reproduce
The entered tags become blank when we click the save button on the SEO configuration page.
Steps to reproduce
1) Create Widget Page
2) Select layout, enter tags and save it
3) Navigate to SEO, enter any keywords and save it.
4) Navigate to the General page, tags will no longer be visible.
Note: same case for the 'Topic' field.

Expected Behavior: After saving the SEO keywords, the entered Tags should reappear.
Observed Behavior: After saving the SEO keywords, the entered tags disappear.
