### PR TITLE
[TS]LPS-140712 Update success message is displayed when adding a user to an organization

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_organizations.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_organizations.jsp
@@ -56,6 +56,8 @@ if (filterManageableOrganizations) {
 }
 %>
 
+<liferay-ui:success key="userAdded" message="the-user-was-created-successfully" />
+
 <c:choose>
 	<c:when test="<%= showList %>">
 


### PR DESCRIPTION
The original implement is from https://github.com/sontruongces/liferay-portal/pull/2
This has passed my review
The issue is described in https://issues.liferay.com/browse/LPP-42878
### Problem overview
There is a case after Adding user to a organization it will redirect to the page organization list. This page misses the tag to recognize the key. @sontruongces fixed this by adding that key to the page
### Steps to reproduce
1. Start server and login
2. Navigate to Users and Organizations > Organizations Tab
3. Create a new organization via the Add button
4. Add new user to organization directly from Org Action Menu
5. Observe that no success message is observed when we save the record

Expected result
A success message appears indicating the addition of the user to the organization was completed

Actual result
Notice the success message doesn't appear and redirection happens directly on the Organization List page