### PR TITLE
LPS-140715 Escape ddm field name to prevent xss

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/io/DDMFormValuesJSONDeserializer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/io/DDMFormValuesJSONDeserializer.java
@@ -136,7 +136,14 @@ public class DDMFormValuesJSONDeserializer
 
 		ddmFormFieldValue.setFieldReference(
 			jsonObject.getString("fieldReference"));
-		ddmFormFieldValue.setInstanceId(jsonObject.getString("instanceId"));
+
+		String instanceId = jsonObject.getString("instanceId");
+
+		if (!instanceId.matches("[a-z]*")) {
+			return null;
+		}
+
+		ddmFormFieldValue.setInstanceId(instanceId);
 		ddmFormFieldValue.setName(jsonObject.getString("name"));
 
 		setDDMFormFieldValueValue(
@@ -169,7 +176,9 @@ public class DDMFormValuesJSONDeserializer
 			DDMFormFieldValue ddmFormFieldValue = getDDMFormFieldValue(
 				jsonArray.getJSONObject(i), ddmFormFieldsMap);
 
-			ddmFormFieldValues.add(ddmFormFieldValue);
+			if (ddmFormFieldValue != null) {
+				ddmFormFieldValues.add(ddmFormFieldValue);
+			}
 		}
 
 		return ddmFormFieldValues;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/java/com/liferay/dynamic/data/mapping/internal/io/DDMFormValuesJSONDeserializerTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/java/com/liferay/dynamic/data/mapping/internal/io/DDMFormValuesJSONDeserializerTest.java
@@ -112,6 +112,35 @@ public class DDMFormValuesJSONDeserializerTest extends BaseDDMTestCase {
 	}
 
 	@Test
+	public void testDeserializationWithInvalidInstanceId() throws Exception {
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
+
+		String serializedDDMFormValues = read(
+			"ddm-form-values-json-deserializer-invalid-instanceId.json");
+
+		DDMFormValues ddmFormValues = deserialize(
+			serializedDDMFormValues, ddmForm);
+
+		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
+			ddmFormValues.getDDMFormFieldValuesMap();
+
+		Assert.assertEquals(
+			ddmFormFieldValuesMap.toString(), 1, ddmFormFieldValuesMap.size());
+
+		List<DDMFormFieldValue> ddmFormFieldValues = ddmFormFieldValuesMap.get(
+			"Select1");
+
+		Assert.assertEquals(
+			ddmFormFieldValues.toString(), 1, ddmFormFieldValues.size());
+
+		DDMFormFieldValue validDDMFormFieldValue = ddmFormFieldValues.get(0);
+
+		Assert.assertEquals(
+			ddmFormFieldValues.toString(), "yhar",
+			validDDMFormFieldValue.getInstanceId());
+	}
+
+	@Test
 	public void testDeserializationWithParentRepeatableField()
 		throws Exception {
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/resources/com/liferay/dynamic/data/mapping/internal/io/dependencies/ddm-form-values-json-deserializer-invalid-instanceId.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/resources/com/liferay/dynamic/data/mapping/internal/io/dependencies/ddm-form-values-json-deserializer-invalid-instanceId.json
@@ -1,0 +1,30 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"defaultLanguageId": "en_US",
+	"fieldValues": [
+		{
+			"instanceId": "<script>alert(document.location)</script>",
+			"name": "Text1",
+			"value": ""
+		},
+		{
+			"instanceId": "^%&214214JDJ",
+			"name": "Text2",
+			"value": ""
+		},
+		{
+			"instanceId": "234S",
+			"name": "Text3",
+			"value": ""
+		},
+		{
+			"instanceId": "yhar",
+			"name": "Select1",
+			"value": {
+				"en_US": "[]"
+			}
+		}
+	]
+}


### PR DESCRIPTION
The issue is described in https://issues.liferay.com/browse/LPP-42863

**Problem overview**
Publishing a Web Content article via cURL which includes a script in the instanceId field allows the script to be executed when accessed

**Steps to reproduce**
Start server and login
1. Sign in as test@liferay.com
2. Go to Web Content > Basic Web Content
3. Open up the browser's dev console and go to the Network section
4. Submit the content, making note of the request that submitted the content. Copy the request as a cURL request.
4. When you get the cURL request, paste it into any text editor, then look for the "instanceId" in a JSON object (in that cURL).
5. Replace the "instanceId" with an executable script, for example: <script>alert(document.location)</script>
6. Copy the new cURL then execute it in a Terminal Command
7. Navigate to the Web Content, access the latest Web Content you have just created.

**Actual Result:**
The script is executed on the Browser and the Page is corrupted

**Expected Result:**
The script must not be executed

Note: This bug cannot reproduce on the master, but the problematic code still exists.