### PR TITLE
LPS-140715 Validate instanceId to prevent xss

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/io/DDMFormValuesJSONDeserializer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/io/DDMFormValuesJSONDeserializer.java
@@ -136,7 +136,14 @@ public class DDMFormValuesJSONDeserializer
 
 		ddmFormFieldValue.setFieldReference(
 			jsonObject.getString("fieldReference"));
-		ddmFormFieldValue.setInstanceId(jsonObject.getString("instanceId"));
+
+		String instanceId = jsonObject.getString("instanceId");
+
+		if (!instanceId.matches("[a-zA-Z0-9]*")) {
+			return null;
+		}
+
+		ddmFormFieldValue.setInstanceId(instanceId);
 		ddmFormFieldValue.setName(jsonObject.getString("name"));
 
 		setDDMFormFieldValueValue(
@@ -169,7 +176,9 @@ public class DDMFormValuesJSONDeserializer
 			DDMFormFieldValue ddmFormFieldValue = getDDMFormFieldValue(
 				jsonArray.getJSONObject(i), ddmFormFieldsMap);
 
-			ddmFormFieldValues.add(ddmFormFieldValue);
+			if (ddmFormFieldValue != null) {
+				ddmFormFieldValues.add(ddmFormFieldValue);
+			}
 		}
 
 		return ddmFormFieldValues;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/java/com/liferay/dynamic/data/mapping/internal/io/DDMFormValuesJSONDeserializerTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/java/com/liferay/dynamic/data/mapping/internal/io/DDMFormValuesJSONDeserializerTest.java
@@ -112,6 +112,35 @@ public class DDMFormValuesJSONDeserializerTest extends BaseDDMTestCase {
 	}
 
 	@Test
+	public void testDeserializationWithInvalidInstanceId() throws Exception {
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
+
+		String serializedDDMFormValues = read(
+			"ddm-form-values-json-deserializer-invalid-instanceId.json");
+
+		DDMFormValues ddmFormValues = deserialize(
+			serializedDDMFormValues, ddmForm);
+
+		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
+			ddmFormValues.getDDMFormFieldValuesMap();
+
+		Assert.assertEquals(
+			ddmFormFieldValuesMap.toString(), 2, ddmFormFieldValuesMap.size());
+
+		List<DDMFormFieldValue> ddmFormFieldValues = ddmFormFieldValuesMap.get(
+			"Select1");
+
+		Assert.assertEquals(
+			ddmFormFieldValues.toString(), 1, ddmFormFieldValues.size());
+
+		DDMFormFieldValue validDDMFormFieldValue = ddmFormFieldValues.get(0);
+
+		Assert.assertEquals(
+			ddmFormFieldValues.toString(), "yhar",
+			validDDMFormFieldValue.getInstanceId());
+	}
+
+	@Test
 	public void testDeserializationWithParentRepeatableField()
 		throws Exception {
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/resources/com/liferay/dynamic/data/mapping/internal/io/dependencies/ddm-form-values-json-deserializer-invalid-instanceId.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/resources/com/liferay/dynamic/data/mapping/internal/io/dependencies/ddm-form-values-json-deserializer-invalid-instanceId.json
@@ -1,0 +1,32 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"defaultLanguageId": "en_US",
+	"fieldValues": [
+		{
+			"instanceId": "<script>alert(document.location)</script>",
+			"name": "Text1",
+			"value": ""
+		},
+		{
+			"instanceId": "^%&214214JDJ",
+			"name": "Text2",
+			"value": ""
+		},
+		{
+			"instanceId": "yhar",
+			"name": "Select1",
+			"value": {
+				"en_US": "[]"
+			}
+		},
+		{
+			"instanceId": "yhKiArYe",
+			"name": "Select2",
+			"value": {
+				"en_US": "[]"
+			}
+		}
+	]
+}


### PR DESCRIPTION
Hi @holatuwol ,
I'm resubmitting the solution since the https://github.com/liferay-ts-reviewer/liferay-portal/pull/5 was closed.

On [DDMFormFieldValue.java#L168](https://github.com/liferay/liferay-portal-ee/blob/master/portal-kernel/src/com/liferay/dynamic/data/mapping/kernel/DDMFormFieldValue.java#L168) it uses StringUtil.randomString() to initialize the default Id. So I think it also accepts uppercase and number. Although, [DDMFormFieldFreeMarkerRenderer.java#L361](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java#L361) StringUtil.randomId(8) and only generate lowercase id. 