### PR TITLE
LPS-141922 "assetentry.title" is not updated when restoring content

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -4393,7 +4393,7 @@ public class JournalArticleLocalServiceImpl
 		if (visible) {
 			_assetEntryLocalService.updateVisible(
 				JournalArticle.class.getName(), article.getResourcePrimKey(),
-				true);
+				article.getTitleMapAsXML(), true);
 		}
 
 		// Comment

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -993,6 +993,7 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		return updateVisible(entry, visible);
 	}
 
+	@Override
 	public AssetEntry updateVisible(
 		String className, long classPK, String title, boolean visible)
 		throws PortalException {

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -993,6 +993,17 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		return updateVisible(entry, visible);
 	}
 
+	public AssetEntry updateVisible(
+		String className, long classPK, String title, boolean visible)
+		throws PortalException {
+
+		AssetEntry entry = assetEntryPersistence.findByC_C(
+			_classNameLocalService.getClassNameId(className), classPK);
+		entry.setTitle(title);
+
+		return updateVisible(entry, visible);
+	}
+
 	@Override
 	public void validate(
 			long groupId, String className, long classPK, long classTypePK,

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -995,11 +995,12 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 
 	@Override
 	public AssetEntry updateVisible(
-		String className, long classPK, String title, boolean visible)
+			String className, long classPK, String title, boolean visible)
 		throws PortalException {
 
 		AssetEntry entry = assetEntryPersistence.findByC_C(
 			_classNameLocalService.getClassNameId(className), classPK);
+
 		entry.setTitle(title);
 
 		return updateVisible(entry, visible);

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalService.java
@@ -575,6 +575,10 @@ public interface AssetEntryLocalService
 			String className, long classPK, boolean visible)
 		throws PortalException;
 
+	public AssetEntry updateVisible(
+			String className, long classPK, String title, boolean visible)
+		throws PortalException;
+
 	public void validate(
 			long groupId, String className, long classPK, long classTypePK,
 			long[] categoryIds, String[] tagNames)

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalServiceUtil.java
@@ -793,6 +793,13 @@ public class AssetEntryLocalServiceUtil {
 		return getService().updateVisible(className, classPK, visible);
 	}
 
+	public static AssetEntry updateVisible(
+			String className, long classPK, String title, boolean visible)
+		throws PortalException {
+
+		return getService().updateVisible(className, classPK, title, visible);
+	}
+
 	public static void validate(
 			long groupId, String className, long classPK, long classTypePK,
 			long[] categoryIds, String[] tagNames)

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalServiceWrapper.java
@@ -897,6 +897,15 @@ public class AssetEntryLocalServiceWrapper
 	}
 
 	@Override
+	public AssetEntry updateVisible(
+			String className, long classPK, String title, boolean visible)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _assetEntryLocalService.updateVisible(
+			className, classPK, title, visible);
+	}
+
+	@Override
 	public void validate(
 			long groupId, String className, long classPK, long classTypePK,
 			long[] categoryIds, String[] tagNames)


### PR DESCRIPTION
When restoring a Web-content from trash, it will get the latest journal-article with the latest title. But when get the asset-entry from that journal-article, it only use 2 params ResourcePrimKey and ClassName, so when the AssetEntryPersistence queries in the DB by those 2 params, the asset-entry now have the old title and when updating, the title will not change. The solution to have the latest title is when get the asset-entry from journal-article, we have to send the latest title also to set the title field of asset-entry before updating. So that I create a new updateVisible() method with a new param - title.