### PR TITLE
LPS-147234 Update the ContentImagesUpgradeProcess could identify the fileEntry in the dynamic element data

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/helper/JournalArticleImageUpgradeHelper.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/helper/JournalArticleImageUpgradeHelper.java
@@ -22,6 +22,8 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -72,6 +74,32 @@ public class JournalArticleImageUpgradeHelper {
 		}
 
 		return StringPool.BLANK;
+	}
+
+	public FileEntry getFileEntryFromData(String data) {
+		FileEntry fileEntry = null;
+
+		try {
+			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(data);
+
+			long groupId = GetterUtil.getLong(jsonObject.get("groupId"));
+			String uuid = GetterUtil.getString(jsonObject.get("uuid"));
+
+			fileEntry = _dlAppLocalService.getFileEntryByUuidAndGroupId(
+				uuid, groupId);
+		}
+		catch (PortalException portalException) {
+			String message = "Unable to get file entry from data " + data;
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(message, portalException);
+			}
+			else if (_log.isWarnEnabled()) {
+				_log.warn(message);
+			}
+		}
+
+		return fileEntry;
 	}
 
 	public FileEntry getFileEntryFromURL(String url) {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_5/ContentImagesUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_5/ContentImagesUpgradeProcess.java
@@ -102,6 +102,12 @@ public class ContentImagesUpgradeProcess extends UpgradeProcess {
 						fileEntry =
 							_journalArticleImageUpgradeHelper.
 								getFileEntryFromURL(data);
+
+						if (fileEntry == null) {
+							fileEntry =
+								_journalArticleImageUpgradeHelper.
+									getFileEntryFromData(data);
+						}
 					}
 				}
 


### PR DESCRIPTION
The original implementation is from https://github.com/binhtran92/liferay-portal/pull/39
This one has passed my review
The issue is described in the ticket: [LPS-147234](https://issues.liferay.com/browse/LPS-147234)
 
### Problem overview
The ContentImagesUpgradeProcess is only implemented for handling getting file entries from URL. 
It is missing for the case web content is created from custom structured which have an image field.
So @hongvo2308 implemented a function for handling this case. 

### Steps to reproduce
Start bundle CE 7.1GA1
Create a Web Content Structure with Image field
Create a Template for that Structure
Create a Web Content with the new Structure
Make sure you add an image to the image field
Copy the data folder to bundle 7.4GA10
Execute the upgrade database tool in the 7.4GA10
Start Bundle CE 7.4GA10
Access to the web content you created before

**Actual result**
The Image field is blank.

**Expected result**
The web content has image information.