### PR TITLE
LPS-148632 Unescape Structure names in Web Content list showed after click on Plus button

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -114,7 +114,7 @@ const CreationMenu = ({
 				symbolLeft={item.icon}
 				{...getDataAttributes(item.data)}
 			>
-				{item.label}
+				{Liferay.Util.unescapeHTML(item.label)}
 			</ClayDropDown.Item>
 		);
 	};


### PR DESCRIPTION
The original PR is from https://github.com/hongvo2308/liferay-portal/pull/16. 
This one has passed my review.
Ticket: [LPS-148632](https://issues.liferay.com/browse/LPS-148632)
Explanation: The Structure name already escape in JournalManagementToolbarDisplayContext.java line 588. And browser will unescape it to show the correct value. But In React, React DOM escapes one more time the value embedded in JSX before rendering them(https://reactjs.org/docs/introducing-jsx.html#jsx-prevents-injection-attacks). So I unescaped it to make it showing the correct name.
Please review it and leave your comments.
Thank you.
CC: @sontruongces