### PR TITLE
LPS-151143 Check null for portletDataContext's layoutIds when exporting Navigation Menu

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
@@ -122,8 +122,10 @@ public class LayoutSiteNavigationMenuItemType
 			return false;
 		}
 
-		if (!ArrayUtil.contains(
-				portletDataContext.getLayoutIds(), layout.getLayoutId())) {
+		long[] layoutIds = portletDataContext.getLayoutIds();
+
+		if ((layoutIds != null) &&
+			!ArrayUtil.contains(layoutIds, layout.getLayoutId())) {
 
 			return false;
 		}


### PR DESCRIPTION
Hi team!
This PR for fixing https://issues.liferay.com/browse/LPS-151143 from @thienquach87
As his explanation: "The bug is to come from the exporting Navigation Menus process working incorrectly. The Site Navigation Menu Items are missing when the Site Navigation is exported. I added check null condition to fix it."
The original PR has passed my review (https://github.com/quanhuynhces/liferay-portal/pull/3)
Please review and leave your comment.
Cheers

cc @thienquach87
