### PR TITLE
LPS-156881 Using lowercase 'a' as object field name is displayed as '%A'

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/table/FDSTableSchemaField.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/table/FDSTableSchemaField.java
@@ -52,6 +52,10 @@ public class FDSTableSchemaField {
 		return _expand;
 	}
 
+	public boolean isLocalizeLabel() {
+		return _localizeLabel;
+	}
+
 	public boolean isSortable() {
 		return _sortable;
 	}
@@ -94,6 +98,12 @@ public class FDSTableSchemaField {
 		return this;
 	}
 
+	public FDSTableSchemaField setLocalizeLabel(boolean localizeLabel) {
+		_localizeLabel = localizeLabel;
+
+		return this;
+	}
+
 	public FDSTableSchemaField setSortable(boolean sortable) {
 		_sortable = sortable;
 
@@ -127,6 +137,8 @@ public class FDSTableSchemaField {
 				return fieldName;
 			}
 		).put(
+			"localizeLabel", isLocalizeLabel()
+		).put(
 			"sortable", isSortable()
 		).put(
 			"sortingOrder",
@@ -155,6 +167,7 @@ public class FDSTableSchemaField {
 	private boolean _expand;
 	private String _fieldName;
 	private String _label;
+	private boolean _localizeLabel;
 	private boolean _sortable;
 	private SortingOrder _sortingOrder;
 

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/view/table/TableFDSViewContextContributor.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/view/table/TableFDSViewContextContributor.java
@@ -73,8 +73,11 @@ public class TableFDSViewContextContributor
 			locale);
 
 		for (FDSTableSchemaField fdsTableSchemaField : fieldsMap.values()) {
-			String label = LanguageUtil.get(
-				resourceBundle, fdsTableSchemaField.getLabel());
+			String label = fdsTableSchemaField.getLabel();
+
+			if (fdsTableSchemaField.isLocalizeLabel()) {
+				label = LanguageUtil.get(resourceBundle, label);
+			}
 
 			if (Validator.isNull(label)) {
 				label = StringPool.BLANK;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/view/table/ObjectEntriesTableFDSView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/view/table/ObjectEntriesTableFDSView.java
@@ -136,9 +136,11 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 	private void _addFDSTableSchemaField(
 		String businessType, String contentRenderer, String dbType,
 		FDSTableSchemaBuilder fdsTableSchemaBuilder, String fieldName,
-		String label, boolean sortable) {
+		String label, boolean sortable, boolean localizeLabel) {
 
 		FDSTableSchemaField fdsTableSchemaField = new FDSTableSchemaField();
+
+		fdsTableSchemaField.setLocalizeLabel(localizeLabel);
 
 		if (Objects.equals(
 				businessType, ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT) ||
@@ -151,6 +153,7 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 			stringFDSTableSchemaField.setFieldName(fieldName);
 			stringFDSTableSchemaField.setLabel(label);
 			stringFDSTableSchemaField.setTruncate(true);
+			stringFDSTableSchemaField.setLocalizeLabel(localizeLabel);
 
 			fdsTableSchemaBuilder.add(stringFDSTableSchemaField);
 
@@ -163,6 +166,7 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 			dateFDSTableSchemaField.setFieldName(fieldName);
 			dateFDSTableSchemaField.setFormat("short");
 			dateFDSTableSchemaField.setLabel(label);
+			dateFDSTableSchemaField.setLocalizeLabel(localizeLabel);
 
 			fdsTableSchemaBuilder.add(dateFDSTableSchemaField);
 
@@ -199,29 +203,29 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 		if (Objects.equals(fieldName, "creator")) {
 			_addFDSTableSchemaField(
 				null, null, null, fdsTableSchemaBuilder, fieldName + ".name",
-				fieldLabel, true);
+				fieldLabel, true, true);
 		}
 		else if (Objects.equals(fieldName, "dateCreated")) {
 			_addFDSTableSchemaField(
 				null, null, "Date", fdsTableSchemaBuilder, fieldName,
-				fieldLabel, true);
+				fieldLabel, true, true);
 		}
 		else if (Objects.equals(fieldName, "dateModified")) {
 			_addFDSTableSchemaField(
 				null, null, "Date", fdsTableSchemaBuilder, fieldName,
-				fieldLabel, true);
+				fieldLabel, true, true);
 		}
 		else if (Objects.equals(fieldName, "externalReferenceCode") ||
 				 Objects.equals(fieldName, "id")) {
 
 			_addFDSTableSchemaField(
 				null, "actionLink", null, fdsTableSchemaBuilder,
-				"externalReferenceCode", fieldLabel, true);
+				"externalReferenceCode", fieldLabel, true, true);
 		}
 		else if (Objects.equals(fieldName, "status")) {
 			_addFDSTableSchemaField(
 				null, "status", null, fdsTableSchemaBuilder, fieldName,
-				fieldLabel, true);
+				fieldLabel, true, true);
 		}
 	}
 
@@ -239,7 +243,7 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 				fdsTableSchemaBuilder,
 				_getFieldName(
 					objectField.getBusinessType(), objectField.getName()),
-				label, objectField.isIndexed());
+				label, objectField.isIndexed(), false);
 		}
 		else if (Objects.equals(
 					objectField.getRelationshipType(),
@@ -262,7 +266,7 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 				_addFDSTableSchemaField(
 					objectField.getBusinessType(), null,
 					objectField.getDBType(), fdsTableSchemaBuilder,
-					objectField.getName(), label, false);
+					objectField.getName(), label, false, false);
 			}
 			else {
 				_addFDSTableSchemaField(
@@ -274,7 +278,7 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 							StringUtil.replaceLast(
 								objectField.getName(), "Id", ""),
 							StringPool.PERIOD, titleObjectField.getName())),
-					label, false);
+					label, false, false);
 			}
 		}
 	}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/details.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/details.jsp
@@ -104,7 +104,7 @@ renderResponse.setTitle(LanguageUtil.format(request, "edit-x", objectDefinition.
 							for (ObjectField objectField : nonrelationshipObjectFields) {
 							%>
 
-								<aui:option label="<%= objectField.getLabel(locale) %>" selected="<%= Objects.equals(objectField.getObjectFieldId(), objectDefinition.getTitleObjectFieldId()) %>" value="<%= objectField.getObjectFieldId() %>" />
+								<aui:option label="<%= objectField.getLabel(locale) %>" localizeLabel="<%= false %>" selected="<%= Objects.equals(objectField.getObjectFieldId(), objectDefinition.getTitleObjectFieldId()) %>" value="<%= objectField.getObjectFieldId() %>" />
 
 							<%
 							}


### PR DESCRIPTION
@holatuwol, This is the fix for [LPS-156881](https://issues.liferay.com/browse/LPS-156881). The original PR at sontruongces#18 has passed my review.

The fix for the Object component but there are changes in FDSDisplay from the frontend infra team. So I wanna make sure that this solution looks good before sending a PR to their team. Please help me to review and give me feedback.
cc: @TaiPhamLR

Thanks!